### PR TITLE
Few fix

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -142,6 +142,7 @@
     color: black;
     
     .post_title {
+      width: 90%;
       font-size: 20px;
       font-weight: bold;
       margin-bottom: 15px;
@@ -200,6 +201,7 @@ post/show
   float: left;
 
   .post_show_title {
+    width: 90%;
     font-size: 30px;
     font-weight: bold;
     letter-spacing: 3px;
@@ -417,6 +419,7 @@ post/new
 
     .post_show_title {
       font-size: 20px;
+      
     }
   
     .show_heart img{

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -206,7 +206,7 @@ post/show
     float: left;
   }
   .show_heart img{
-    margin-top: 5px;
+    margin-top: 10px;
     
   }
   .link_container{

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,6 +89,8 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  config.logger = Logger.new("log/production.log", 'weekly')
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
一週間以前のproduction.logを切り捨てるようログローテートの設定
→production.logが溜まり、残りの容量がギリギリになっていた。（画像投稿できないほど）
そのためproduction.logを全て削除し、加えて、一週間以前のproduction.logを切り捨てるようログローテートを設定した。